### PR TITLE
Fixes Youtube New Trusted Types CSP

### DIFF
--- a/YtLowViewFilter.user.js
+++ b/YtLowViewFilter.user.js
@@ -55,7 +55,7 @@
         // Preview mode: show filtered items with highlight instead of hiding
         previewMode: JSON.parse(localStorage.getItem("ytvf_preview") || "false"),
     };
-    //Fixes, de new Youtube Security "Trusted Types" policy
+    //Fixes, due to Youtube's New Security "Trusted Types" policy
     if (window.trustedTypes && window.trustedTypes.createPolicy) { 
         try {
             window.trustedTypes.createPolicy('default', { createHTML: (s) => s });

--- a/YtLowViewFilter.user.js
+++ b/YtLowViewFilter.user.js
@@ -55,7 +55,12 @@
         // Preview mode: show filtered items with highlight instead of hiding
         previewMode: JSON.parse(localStorage.getItem("ytvf_preview") || "false"),
     };
-
+    //Fixes, de new Youtube Security "Trusted Types" policy
+    if (window.trustedTypes && window.trustedTypes.createPolicy) { 
+        try {
+            window.trustedTypes.createPolicy('default', { createHTML: (s) => s });
+        } catch (e) {}
+    }
     /**
      * Persist current state to localStorage.
      */


### PR DESCRIPTION
YouTube recently started strictly enforcing Trusted Types CSP, which blocks raw string assignments to Element.innerHTML (causing a Sink type mismatch violation) and breaks the UI panel. Adding a basic 'default' policy allows the existing innerHTML assignments to pass through without needing to rewrite the entire HTML template structure.